### PR TITLE
Add dump1090 port configuration and serial diagnostics

### DIFF
--- a/config.h
+++ b/config.h
@@ -7,6 +7,7 @@
 
 // ADS-B dump1090 server configuration
 #define DUMP1090_SERVER "127.0.0.1" // IP or hostname of dump1090 server
+#define DUMP1090_PORT 8080          // Port of dump1090 JSON endpoint
 #define USER_LAT 51.5074
 #define USER_LON -0.1278
 


### PR DESCRIPTION
## Summary
- allow specifying dump1090 server port via new `DUMP1090_PORT`
- print detailed Serial diagnostics when fetching aircraft data

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 .` *(fails: Adafruit_SH110X.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b3410270548326b48a794d7435adb5