### PR TITLE
docs: add Codex environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,83 @@ The display refreshes every few seconds showing the closest aircraft's callsign,
 
 The following setup script prepares a Codex/Codespace container with all required tools and
 libraries for this project. Run it in your container before compiling:
+```bash
+#!/bin/bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
 
+echo "==> Base packages"
+apt-get update
+apt-get install -y --no-install-recommends \
+  curl ca-certificates git python3 tar xz-utils
+
+# --- Proxy handling ---
+# Mirror the proxy you see in Codex logs (http://proxy:8080) for all tools.
+HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-$HTTP_PROXY}}"
+NO_PROXY="${NO_PROXY:-${no_proxy:-localhost,127.0.0.1,::1}}"
+export HTTP_PROXY HTTPS_PROXY NO_PROXY
+# Some tools only read lowercase:
+export http_proxy="${HTTP_PROXY:-}"
+export https_proxy="${HTTPS_PROXY:-}"
+export no_proxy="${NO_PROXY:-}"
+
+echo "HTTP_PROXY=${HTTP_PROXY:-<unset>}"
+echo "HTTPS_PROXY=${HTTPS_PROXY:-<unset>}"
+echo "NO_PROXY=${NO_PROXY}"
+
+# --- Prefer IPv4 to avoid IPv6 'network is unreachable' ---
+if ! grep -q '^precedence ::ffff:0:0/96 100' /etc/gai.conf 2>/dev/null; then
+  echo 'precedence ::ffff:0:0/96 100' >> /etc/gai.conf
+fi
+
+# --- Helper: retry with backoff ---
+retry () {
+  local attempts="$1"; shift
+  local sleep_s="$1"; shift
+  local n=1
+  until "$@"; do
+    if [[ $n -ge $attempts ]]; then
+      echo "Command failed after $n attempts: $*" >&2
+      return 1
+    fi
+    echo "Retry $n/$attempts failed. Sleeping ${sleep_s}s…"
+    n=$((n+1))
+    sleep "$sleep_s"
+  done
+}
+
+echo "==> Installing arduino-cli"
+curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
+install -m 0755 bin/arduino-cli /usr/local/bin/arduino-cli
+rm -rf bin
+arduino-cli version
+
+echo "==> arduino-cli config"
+arduino-cli config init --overwrite
+
+# Boards index + proxy (this is the only network key we need)
+arduino-cli config set board_manager.additional_urls \
+  https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+
+if [[ -n "${HTTPS_PROXY}" || -n "${HTTP_PROXY}" ]]; then
+  arduino-cli config set network.proxy "${HTTPS_PROXY:-$HTTP_PROXY}"
+fi
+
+# Optional: slightly longer socket timeout (older CLI versions may ignore this; safe if it errors)
+arduino-cli config set network.socket_timeout 60s || true
+
+echo "==> Updating indexes (via proxy, with retries)"
+retry 5 5 arduino-cli core update-index
+
+echo "==> Installing ESP32 core"
+retry 5 5 arduino-cli core install esp32:esp32
+
+echo "==> Installing libraries"
+retry 5 5 arduino-cli lib install "Adafruit GFX Library"
+retry 5 5 arduino-cli lib install "Adafruit SSD1306"
+retry 5 5 arduino-cli lib install "ArduinoJson"
+
+echo "✅ Setup complete. Compile with:"
+echo "   arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane.ino"
+```


### PR DESCRIPTION
## Summary
- document Codex/Codespace environment setup in README

## Testing
- `bash CodexEnvironment`
- `arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane`


------
https://chatgpt.com/codex/tasks/task_e_68b58431235483268fabe81fc16517dc