### PR TITLE
Add GitHub Action to build firmware

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build-firmware
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Arduino CLI
+        uses: arduino/setup-arduino-cli@v1
+
+      - name: Install platform and libraries
+        run: |
+          arduino-cli core update-index
+          arduino-cli core install esp32:esp32
+          arduino-cli lib install "Adafruit GFX Library"
+          arduino-cli lib install "Adafruit SH110X"
+          arduino-cli lib install "ArduinoJson"
+          arduino-cli lib install "SimpleRotary"
+
+      - name: Compile sketch
+        run: |
+          mkdir -p closestPlane
+          cp closestPlane.ino config.h closestPlane/
+          arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane --output-dir build
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware
+          path: build/*.bin


### PR DESCRIPTION
## Summary
- build ESP32 sketch with Arduino CLI on pushes and PRs
- upload compiled firmware binary as an artifact

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane --output-dir build`

------
https://chatgpt.com/codex/tasks/task_e_68b5bb7e5574832689be6080429a9135