### PR TITLE
Add release step to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -27,10 +30,19 @@ jobs:
         run: |
           mkdir -p closestPlane
           cp closestPlane.ino config.h closestPlane/
-          arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane --output-dir build
+          arduino-cli compile \
+            --fqbn esp32:esp32:esp32 \
+            closestPlane \
+            --output-dir build
 
       - name: Upload firmware artifact
         uses: actions/upload-artifact@v4
         with:
           name: firmware
           path: build/*.bin
+
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/*.bin


### PR DESCRIPTION
## Summary
- publish built firmware as a GitHub release when a tag is pushed
- grant workflow permission to create releases

## Testing
- `yamllint .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b5c75053048326976bd30d7d6f3097