### PR TITLE
Document CLI test build and fix Codex environment script

### DIFF
--- a/CodexEnvironment
+++ b/CodexEnvironment
@@ -71,8 +71,10 @@ retry 5 5 arduino-cli core install esp32:esp32
 
 echo "==> Installing libraries"
 retry 5 5 arduino-cli lib install "Adafruit GFX Library"
-retry 5 5 arduino-cli lib install "Adafruit SSD1306"
+retry 5 5 arduino-cli lib install "Adafruit SH110X"
 retry 5 5 arduino-cli lib install "ArduinoJson"
+retry 5 5 arduino-cli lib install "SimpleRotary"
 
 echo "✅ Setup complete. Compile with:"
 echo "   arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane.ino"
+

--- a/README.md
+++ b/README.md
@@ -120,3 +120,11 @@ retry 5 5 arduino-cli lib install "SimpleRotary"
 echo "✅ Setup complete. Compile with:"
 echo "   arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane.ino"
 ```
+
+This repository also includes the setup script above as `CodexEnvironment`. Run `./CodexEnvironment` in a Codex or Codespace container to install all dependencies. After setup, verify the build with:
+
+```bash
+arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane.ino
+```
+
+The command completes successfully when the required libraries (Adafruit SH110X, SimpleRotary, etc.) are installed.


### PR DESCRIPTION
## Summary
- document CodexEnvironment setup script and add CLI build verification instructions
- fix CodexEnvironment script to install SH110X and SimpleRotary libraries

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane`

------
https://chatgpt.com/codex/tasks/task_e_68b6b7a7375c832688439cad3645f934