### PR TITLE
Simplify dotted circle loop

### DIFF
--- a/closestPlane.ino
+++ b/closestPlane.ino
@@ -608,13 +608,11 @@ double calculateBearing(double lat1, double lon1, double lat2, double lon2) {
 
 // Custom function to draw a dotted circle
 void drawDottedCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color) {
-  for (int i = 0; i < 360; i++) {
-    if (i % 30 == 0) { 
-      double angleRad = i * PI / 180.0;
-      int16_t x = x0 + r * sin(angleRad);
-      int16_t y = y0 - r * cos(angleRad);
-      display.drawPixel(x, y, color);
-    }
+  for (int i = 0; i < 360; i += 30) {
+    double angleRad = i * PI / 180.0;
+    int16_t x = x0 + r * sin(angleRad);
+    int16_t y = y0 - r * cos(angleRad);
+    display.drawPixel(x, y, color);
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace per-degree loop and modulus check with 30° step iteration in `drawDottedCircle` to render 12 evenly spaced dots.

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 .`
- `python - <<'PY'
import math
angles=list(range(0,360,30))
print('angles:', angles)
print('count:', len(angles))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b751c8a65c8326b6fe769542bcf3de