### PR TITLE
Display alert distance on main radar screen

### DIFF
--- a/closestPlane.ino
+++ b/closestPlane.ino
@@ -485,6 +485,9 @@ void drawRadarScreen() {
     }
     display.print("Rng: ");
     display.print(radarRangeKm, 0);
+    display.println("km");
+    display.print("Prox: ");
+    display.print(inboundAlertDistanceKm, 0);
     display.print("km");
   } else {
     display.setCursor(0, 0);
@@ -492,6 +495,9 @@ void drawRadarScreen() {
     display.setCursor(0, 16);
     display.print("Range:");
     display.print(radarRangeKm, 0);
+    display.println("km");
+    display.print("Prox: ");
+    display.print(inboundAlertDistanceKm, 0);
     display.print("km");
   }
 


### PR DESCRIPTION
## Summary
- show current proximity alert distance alongside range info on the OLED

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 /tmp/closestPlane`


------
https://chatgpt.com/codex/tasks/task_e_68bde6e1b3e48326ba4725ba90c37aa0