### PR TITLE
Document proximity alert behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Connect the following components to your ESP32:
 - Long-press the volume encoder to power off.
 - Settings persist in EEPROM and a small antenna icon indicates a good data connection.
 - Aircraft predicted to pass within the alert radius flash on the radar and trigger a single alert tone. The display shows minutes until the closest inbound aircraft reaches minimum distance.
+- Each aircraft is tracked individually in an `alertedFlights` list so it will only trigger the siren once while inbound.
+- The alarm sounds again only if that aircraft leaves the inbound zone (bearing difference over 90° or cross-track distance beyond the alert radius) and later re-enters, or if a different aircraft meets the inbound criteria.
 
 ## Building in a Codex/Codespace Environment
 


### PR DESCRIPTION
## Summary
- note proximity alert tracks each aircraft once while inbound
- describe when alarm will sound again after firing

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 .` *(fails: Can't open sketch: main file missing from sketch: /workspace/ESP32-closestPlane/ESP32-closestPlane.ino)*

------
https://chatgpt.com/codex/tasks/task_e_68bdea1013c88326807baf79638480df