### PR TITLE
Remove redundant proximity readout from main info

### DIFF
--- a/closestPlane.ino
+++ b/closestPlane.ino
@@ -432,9 +432,6 @@ void drawRadarScreen() {
     display.print("Rng: ");
     display.print(radarRangeKm, 0);
     display.println("km");
-    display.print("Prox: ");
-    display.print(inboundAlertDistanceKm, 0);
-    display.print("km");
   } else {
     display.setCursor(0, 8);
     display.println("Scanning...");
@@ -442,9 +439,6 @@ void drawRadarScreen() {
     display.print("Range:");
     display.print(radarRangeKm, 0);
     display.println("km");
-    display.print("Prox: ");
-    display.print(inboundAlertDistanceKm, 0);
-    display.print("km");
   }
 
   if (currentClosestInbound.isInbound && currentClosestInbound.minutesToClosest >= 0) {


### PR DESCRIPTION
## Summary
- omit proximity from aircraft info area since already shown in header

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 /tmp/closestPlane`


------
https://chatgpt.com/codex/tasks/task_e_68bf03069e8083268db4d1d369e9d65a