### PR TITLE
feat: add radar parameter selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Connect the following components to your ESP32:
 ## Operation
 - The display shows a radar sweep of aircraft within range. Each time the sweep crosses a target a short beep is produced.
 - Rotate the range encoder to adjust radar range.
-- Press the range encoder to cycle the volume encoder between controlling beep volume, sweep speed and alert distance.
-- Rotate the volume encoder to adjust the selected parameter.
+- Press the range encoder to cycle the volume encoder between controlling beep volume, sweep speed, alert distance, and the radar compass point (indicated by an inverted "N").
+- Rotate the volume encoder to adjust the selected parameter (no action when radar is selected).
 - Long-press the volume encoder to power off.
 - Settings persist in EEPROM and a small antenna icon indicates a good data connection.
 - Aircraft predicted to pass within the alert radius flash on the radar and trigger a single alert tone. The display shows minutes until the closest inbound aircraft reaches minimum distance.


### PR DESCRIPTION
## Summary
- allow cycling to a Radar mode in parameter selection
- invert the north marker when Radar is selected
- document radar compass parameter usage

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 closestPlane.ino` (fails: main file missing from sketch)


------
https://chatgpt.com/codex/tasks/task_e_68bf16fdb6d88326aff08c98e58e357f