### PR TITLE
Enable radar compass rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Connect the following components to your ESP32:
 - The display shows a radar sweep of aircraft within range. Each time the sweep crosses a target a short beep is produced.
 - Rotate the range encoder to adjust radar range.
 - Press the range encoder to cycle the volume encoder between controlling beep volume, sweep speed, alert distance, and the radar compass point (indicated by an inverted "N").
-- Rotate the volume encoder to adjust the selected parameter (no action when radar is selected).
+- Rotate the volume encoder to adjust the selected parameter or to rotate the radar through the four compass points when compass mode is selected.
 - Long-press the volume encoder to power off.
 - Settings persist in EEPROM and a small antenna icon indicates a good data connection.
 - Aircraft predicted to pass within the alert radius flash on the radar and trigger a single alert tone. The display shows minutes until the closest inbound aircraft reaches minimum distance.


### PR DESCRIPTION
## Summary
- Add compass orientation setting with EEPROM storage
- Allow volume encoder to rotate radar through N/E/S/W
- Show current compass point on display and update README

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 /tmp/closestPlane`


------
https://chatgpt.com/codex/tasks/task_e_68bf192d8ee48326a39ace7f78c92b24