### PR TITLE
Swap rotary encoder rotation functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Connect the following components to your ESP32:
 
 - **SH1106 128×64 OLED** (I²C): SDA → GPIO21, SCL → GPIO22, plus 3.3 V and GND.
 - **MAX98357A I2S amplifier**: BCLK → GPIO17, LRCLK → GPIO16, DIN → GPIO27, SD → GPIO19, 3.3 V and GND.
-- **Volume rotary encoder**: A → GPIO33, B → GPIO4, switch → GPIO23.
-- **Range/channel rotary encoder**: A → GPIO25, B → GPIO32, switch → GPIO2.
+- **Range rotary encoder**: A → GPIO33, B → GPIO4, switch → GPIO23.
+- **Mode/volume rotary encoder**: A → GPIO25, B → GPIO32, switch → GPIO2.
 
 ## Setup
 1. Rename `config.h` with your WiFi credentials, dump1090 server address and your latitude/longitude. Adjust I2S pin numbers if required.
@@ -29,10 +29,10 @@ Connect the following components to your ESP32:
 
 ## Operation
 - The display shows a radar sweep of aircraft within range. Each time the sweep crosses a target a short beep is produced.
+- Rotate the mode/volume encoder to adjust beep volume, sweep speed, alert distance, or to rotate the radar through the four compass points when compass mode is selected.
+- Press the mode/volume encoder to cycle between these control modes.
 - Rotate the range encoder to adjust radar range.
-- Press the range encoder to cycle the volume encoder between controlling beep volume, sweep speed, alert distance, and the radar compass point (indicated by an inverted "N").
-- Rotate the volume encoder to adjust the selected parameter or to rotate the radar through the four compass points when compass mode is selected.
-- Long-press the volume encoder to power off.
+- Long-press the range encoder to power off.
 - Settings persist in EEPROM and a small antenna icon indicates a good data connection.
 - Aircraft predicted to pass within the alert radius flash on the radar and trigger a single alert tone. The display shows minutes until the closest inbound aircraft reaches minimum distance.
 - Each aircraft is tracked individually in an `alertedFlights` list so it will only trigger the siren once while inbound.

--- a/closestPlane.ino
+++ b/closestPlane.ino
@@ -41,7 +41,9 @@
 
 // --- Display & Rotary Objects ---
 Adafruit_SH1106G display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
+// Rotary wired as "volume" now adjusts radar range (switch still powers off)
 SimpleRotary VolumeSelector(33, 4, 23);
+// Rotary wired as "channel" now controls volume/speed/alert/compass (switch still cycles modes)
 SimpleRotary ChannelSelector(25, 32, 2);
 
 // --- Volatile variables for ISR-safe encoder reading ---
@@ -135,9 +137,9 @@ void drawDottedCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
 void encoderTask(void *pvParameters) {
   for (;;) {
     byte vol_rotate_event = VolumeSelector.rotate();
-    if (vol_rotate_event != 0) { VolumeChange = vol_rotate_event; }
+    if (vol_rotate_event != 0) { ChannelChange = vol_rotate_event; }
     byte chan_rotate_event = ChannelSelector.rotate();
-    if (chan_rotate_event != 0) { ChannelChange = chan_rotate_event; }
+    if (chan_rotate_event != 0) { VolumeChange = chan_rotate_event; }
     byte vol_push_event = VolumeSelector.pushType(200);
     if (vol_push_event != 0) { VolumePush = vol_push_event; }
     byte chan_push_event = ChannelSelector.pushType(200);


### PR DESCRIPTION
## Summary
- Swap rotary rotation assignments so the former range knob now adjusts volume, speed, alert distance and compass, while the former volume knob controls radar range.
- Document the new mapping of encoders in README.

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 .` *(failed: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ab1f518c8326940c459de88391fc