### PR TITLE
Fix Freenove CYD sketch compile errors

### DIFF
--- a/freenove.ino
+++ b/freenove.ino
@@ -345,7 +345,7 @@ void loop() {
       if (bearingCrossed) {
         double angleRad = targetBearing * PI / 180.0;
         double realDistance = trackedAircraft[i].distanceKm;
-        float ratio = radarRangeKm > 0 ? std::min(realDistance / radarRangeKm, 1.0f) : 0.0f;
+        float ratio = radarRangeKm > 0 ? std::min<float>(static_cast<float>(realDistance / radarRangeKm), 1.0f) : 0.0f;
         float screenRadius = ratio * RADAR_RADIUS;
         int16_t newBlipX = RADAR_CENTER_X + screenRadius * sin(angleRad);
         int16_t newBlipY = RADAR_CENTER_Y - screenRadius * cos(angleRad);


### PR DESCRIPTION
## Summary
- remove GCC-designated initializers from the I2S configuration and pin structs so they compile with the Arduino build flags
- qualify ArduinoJson types and add `<cstring>` to satisfy the compiler when parsing aircraft data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c92b24215c832687e0810464e3cac4